### PR TITLE
Fix: Add handler for invalid / blank requests

### DIFF
--- a/src/main/java/httpserver/http/RequestMethod.java
+++ b/src/main/java/httpserver/http/RequestMethod.java
@@ -4,5 +4,6 @@ public enum RequestMethod {
     GET,
     POST,
     OPTIONS,
-    HEAD
+    HEAD,
+    INVALID
 }

--- a/src/main/java/httpserver/http/StatusCode.java
+++ b/src/main/java/httpserver/http/StatusCode.java
@@ -3,6 +3,7 @@ package httpserver.http;
 public enum StatusCode {
     OK("200 OK"),
     MOVED_PERMANENTLY("301 MOVED PERMANENTLY"),
+    BAD_REQUEST("400 BAD REQUEST"),
     NOT_FOUND("404 NOT FOUND"),
     METHOD_NOT_ALLOWED("405 METHOD NOT ALLOWED");
 

--- a/src/main/java/httpserver/http/request/RequestParser.java
+++ b/src/main/java/httpserver/http/request/RequestParser.java
@@ -1,23 +1,24 @@
 package httpserver.http.request;
 
+import httpserver.http.Protocol;
+import httpserver.http.RequestMethod;
+
 public class RequestParser {
-    private final String rawRequest;
-    private final String separator = "\r\n";
+    private String rawRequest;
+    private static final String SEPARATOR = "\r\n";
 
     public RequestParser(String rawRequest) {
         this.rawRequest = rawRequest;
     }
 
     public String getRequestMethod() {
-        var splitRequestLine = splitRequestLine();
-        var requestMethod = splitRequestLine[0];
-        return requestMethod;
+        var splitRequestLine = validateRequestLine();
+        return splitRequestLine[0];
     }
 
     public String getRequestPath() {
-        var splitRequestLine = splitRequestLine();
-        var requestPath = splitRequestLine[1];
-        return requestPath;
+        var splitRequestLine = validateRequestLine();
+        return splitRequestLine[1];
     }
 
     public String getRequestBody() {
@@ -28,7 +29,7 @@ public class RequestParser {
     }
 
     private String[] splitRequest () {
-        return rawRequest.split(separator);
+        return rawRequest.split(SEPARATOR);
     }
 
     private String[] splitRequestLine() {
@@ -39,6 +40,27 @@ public class RequestParser {
     }
 
     private boolean isRequestBodyEmpty() {
-        return rawRequest.endsWith(separator);
+        return rawRequest.endsWith(SEPARATOR);
+    }
+
+    private String[] validateRequestLine() {
+        if (isRequestEmpty()) rawRequest = invalidRequest();
+
+        return splitRequestLine();
+    }
+
+    private boolean isRequestEmpty() {
+        return rawRequest.isEmpty();
+    }
+
+    private String invalidRequest() {
+        var requestMethod = RequestMethod.INVALID.toString();
+        var path = "/";
+        var protocol = Protocol.HTTP_1_1.getVersion();
+        return requestMethod
+                + " "
+                + path
+                + " "
+                + protocol;
     }
 }

--- a/src/main/java/httpserver/http/request/RequestParser.java
+++ b/src/main/java/httpserver/http/request/RequestParser.java
@@ -1,23 +1,20 @@
 package httpserver.http.request;
 
-import httpserver.http.Protocol;
-import httpserver.http.RequestMethod;
-
 public class RequestParser {
-    private String rawRequest;
+    private String clientRequestString;
     private static final String SEPARATOR = "\r\n";
 
-    public RequestParser(String rawRequest) {
-        this.rawRequest = rawRequest;
+    public RequestParser(String clientRequestString) {
+        this.clientRequestString = clientRequestString;
     }
 
     public String getRequestMethod() {
-        var splitRequestLine = validateRequestLine();
+        var splitRequestLine = splitRequestLine();
         return splitRequestLine[0];
     }
 
     public String getRequestPath() {
-        var splitRequestLine = validateRequestLine();
+        var splitRequestLine = splitRequestLine();
         return splitRequestLine[1];
     }
 
@@ -28,39 +25,23 @@ public class RequestParser {
         return splitRequest[splitRequest.length -1];
     }
 
-    private String[] splitRequest () {
-        return rawRequest.split(SEPARATOR);
+    private void validateClientRequestString() {
+        clientRequestString = RequestStringValidator.validate(clientRequestString);
     }
 
     private String[] splitRequestLine() {
+        validateClientRequestString();
         var splitRequest = splitRequest();
         var requestLine = splitRequest[0];
 
         return requestLine.split(" ");
     }
 
+    private String[] splitRequest () {
+        return clientRequestString.split(SEPARATOR);
+    }
+
     private boolean isRequestBodyEmpty() {
-        return rawRequest.endsWith(SEPARATOR);
-    }
-
-    private String[] validateRequestLine() {
-        if (isRequestEmpty()) rawRequest = invalidRequest();
-
-        return splitRequestLine();
-    }
-
-    private boolean isRequestEmpty() {
-        return rawRequest.isEmpty();
-    }
-
-    private String invalidRequest() {
-        var requestMethod = RequestMethod.INVALID.toString();
-        var path = "/";
-        var protocol = Protocol.HTTP_1_1.getVersion();
-        return requestMethod
-                + " "
-                + path
-                + " "
-                + protocol;
+        return clientRequestString.endsWith(SEPARATOR);
     }
 }

--- a/src/main/java/httpserver/http/request/RequestStringValidator.java
+++ b/src/main/java/httpserver/http/request/RequestStringValidator.java
@@ -1,0 +1,29 @@
+package httpserver.http.request;
+
+import httpserver.http.Protocol;
+import httpserver.http.RequestMethod;
+
+public class RequestStringValidator {
+
+    public static String validate(String clientRequestString) {
+        if(isRequestStringEmpty(clientRequestString)) {
+            return invalidRequest();
+        }
+        return clientRequestString;
+    }
+
+    private static boolean isRequestStringEmpty(String clientRequestString) {
+        return clientRequestString.isEmpty();
+    }
+
+    private static String invalidRequest() {
+        var requestMethod = RequestMethod.INVALID.toString();
+        var path = "/";
+        var protocol = Protocol.HTTP_1_1.getVersion();
+        return requestMethod
+                + " "
+                + path
+                + " "
+                + protocol;
+    }
+}

--- a/src/main/java/httpserver/http/route/requestmethod/InvalidMethodHandler.java
+++ b/src/main/java/httpserver/http/route/requestmethod/InvalidMethodHandler.java
@@ -1,0 +1,13 @@
+package httpserver.http.route.requestmethod;
+
+import httpserver.http.StatusCode;
+import httpserver.http.request.Request;
+import httpserver.http.response.Response;
+import httpserver.http.response.ResponseFactory;
+
+public class InvalidMethodHandler extends MethodHandler {
+
+    public Response getResponse(Request request) {
+        return ResponseFactory.build(StatusCode.BAD_REQUEST, null, null, null);
+    }
+}

--- a/src/main/java/httpserver/http/route/requestmethod/MethodHandlerFactory.java
+++ b/src/main/java/httpserver/http/route/requestmethod/MethodHandlerFactory.java
@@ -27,6 +27,8 @@ public class MethodHandlerFactory {
                 return new OptionsMethodHandler();
             case HEAD:
                 return new HeadMethodHandler();
+            case INVALID:
+                return new InvalidMethodHandler();
             default:
                 return new UnknownMethodHandler();
         }

--- a/src/test/java/httpserver/http/request/RequestParserTest.java
+++ b/src/test/java/httpserver/http/request/RequestParserTest.java
@@ -41,9 +41,19 @@ class RequestParserTest {
         var rawRequest = "POST /echo_body HTTP/1.1\r\n\r\n";
 
         var requestBody = new RequestParser(rawRequest).getRequestBody();
-        System.out.println(requestBody);
 
         assertEquals("", requestBody);
+    }
+
+    @Test
+    void returnsARequestLineWithTheInvalidRequestMethodIfRawRequestIsEmpty() {
+        var rawRequest = "";
+
+        var requestMethod = new RequestParser(rawRequest).getRequestMethod();
+        var requestPath = new RequestParser(rawRequest).getRequestPath();
+
+        assertEquals("INVALID", requestMethod);
+        assertEquals("/", requestPath);
     }
 
 }

--- a/src/test/java/httpserver/http/request/RequestStringValidatorTest.java
+++ b/src/test/java/httpserver/http/request/RequestStringValidatorTest.java
@@ -1,0 +1,24 @@
+package httpserver.http.request;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RequestStringValidatorTest {
+
+    @Test
+    void returnsOriginalClientRequestIfItIsNotEmpty() {
+        var clientRequestString = "GET / HTTP/1.1";
+        var validatedRequestString = RequestStringValidator.validate(clientRequestString);
+
+        assertEquals(clientRequestString, validatedRequestString);
+    }
+
+    @Test
+    void returnsNewClientRequestIfOriginalRequestIsEmpty() {
+        var clientRequestString = "";
+        var validatedRequestString = RequestStringValidator.validate(clientRequestString);
+
+        assertEquals("INVALID / HTTP/1.1", validatedRequestString);
+    }
+}

--- a/src/test/java/httpserver/http/route/requestmethod/InvalidMethodHandlerTest.java
+++ b/src/test/java/httpserver/http/route/requestmethod/InvalidMethodHandlerTest.java
@@ -1,0 +1,20 @@
+package httpserver.http.route.requestmethod;
+
+import httpserver.http.request.RequestFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InvalidMethodHandlerTest {
+
+    @Test
+    void getResponse() {
+        var rawRequest = "INVALID / HTTP/1.1";
+        var request = RequestFactory.build(rawRequest);
+        var invalidMethodHandler = new InvalidMethodHandler();
+
+        var response = invalidMethodHandler.getResponse(request);
+
+        assertEquals("HTTP/1.1 400 BAD REQUEST" + "\r\n", response.toString());
+    }
+}

--- a/src/test/java/httpserver/http/route/requestmethod/MethodHandlerFactoryTest.java
+++ b/src/test/java/httpserver/http/route/requestmethod/MethodHandlerFactoryTest.java
@@ -39,4 +39,11 @@ class MethodHandlerFactoryTest {
 
         assertThat(methodHandler).isInstanceOf(UnknownMethodHandler.class);
     }
+
+    @Test
+    void returnsAnInstanceOfInvalidMethodHandlerWhenTheMethodIsInvalid() {
+        var methodHandler = MethodHandlerFactory.getHandler("INVALID");
+
+        assertThat(methodHandler).isInstanceOf(InvalidMethodHandler.class);
+    }
 }


### PR DESCRIPTION
`StatusCode` - Add `BAD_REQUEST`
`RequestMethod` - add `INVALID`
`RequestStringValidator` - returns client request if it is not empty, otherwise returns a request with the `INVALID` request method
`InvalidMethodHandler` - handles requests with the `INVALID` method